### PR TITLE
 fix/update: Add a clientevent which receive a networkId and give keys

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -234,6 +234,10 @@ RegisterNetEvent('vehiclekeys:client:SetOwner', function(plate)
 end)
 -- Backwards Compatibility ONLY -- Remove at some point --
 
+RegisterNetEvent('vehiclekeys:client:SetOwnerByNetworkId', function(vehicleId)
+    TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', QBCore.Functions.GetPlate(NetworkGetEntityFromNetworkId(vehicleId)))
+end)
+
 -----------------------
 ----   Functions   ----
 -----------------------


### PR DESCRIPTION

## Description
Fix the problem of qbx-core when you create a vehicle server side dont player dont receive the keys
Needed to give keys for a car spawned server-side.  If you want an example where it is used, iused it on my pr on in qbx-core to the CreateVehicle server-side function

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
