### PR TITLE
fix(client/main): don't allow to move vehicle while progress bar active

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -436,7 +436,6 @@ function Hotwire(vehicle, plate)
     local ped = cache.ped
     IsHotwiring = true
 
-    SetVehicleEngineOn(vehicle, false, false, true)
     SetVehicleAlarm(vehicle, true)
     SetVehicleAlarmTimeLeft(vehicle, hotwireTime)
     if lib.progressCircle({

--- a/client/main.lua
+++ b/client/main.lua
@@ -436,6 +436,7 @@ function Hotwire(vehicle, plate)
     local ped = cache.ped
     IsHotwiring = true
 
+    SetVehicleEngineOn(vehicle, false, false, true)
     SetVehicleAlarm(vehicle, true)
     SetVehicleAlarmTimeLeft(vehicle, hotwireTime)
     if lib.progressCircle({
@@ -448,12 +449,17 @@ function Hotwire(vehicle, plate)
             dict = 'anim@amb@clubhouse@tutorial@bkr_tut_ig3@',
             clip = 'machinic_loop_mechandplayer'
         },
+        disable = {
+            move = true,
+            car = true,
+            combat = true,
+        }
     }) then
         StopAnimTask(ped, "anim@amb@clubhouse@tutorial@bkr_tut_ig3@", "machinic_loop_mechandplayer", 1.0)
-        TriggerServerEvent('hud:server:GainStress', math.random(1, 4))
         if (math.random() <= Config.HotwireChance) then
             TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', plate)
         else
+            TriggerServerEvent('hud:server:GainStress', math.random(1, 4))
             QBCore.Functions.Notify(Lang:t("notify.failed_lockedpick"), 'error')
         end
         Wait(Config.TimeBetweenHotwires)


### PR DESCRIPTION
## Description

don't allow to move vehicle while progress bar active

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
