### PR TITLE
refactor: move to modules, more ox_lib, style fixes

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,10 +1,11 @@
 fx_version 'cerulean'
 game 'gta5'
 lua54 'yes'
-description 'https://github.com/Qbox-project'
+description 'https://github.com/Qbox-project/qbx-vehiclekeys'
 version '1.0.0'
 
 shared_scripts {
+	'@qbx-core/import.lua',
 	'@qbx-core/shared/locale.lua',
 	'locales/en.lua',
 	'locales/*.lua',
@@ -13,3 +14,9 @@ shared_scripts {
 }
 client_script 'client/main.lua'
 server_script 'server/main.lua'
+
+modules {
+	'qbx-core:core',
+	'qbx-core:playerdata',
+	'qbx-core:utils'
+}

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,8 +1,7 @@
 -----------------------
 ----   Variables   ----
 -----------------------
-local QBCore = exports['qbx-core']:GetCoreObject()
-local VehicleList = {}
+local vehicleList = {}
 
 -----------------------
 ----   Threads     ----
@@ -37,11 +36,11 @@ RegisterNetEvent('qb-vehiclekeys:server:AcquireVehicleKeys', function(plate)
 end)
 
 RegisterNetEvent('qb-vehiclekeys:server:breakLockpick', function(itemName)
-    local Player = QBCore.Functions.GetPlayer(source)
-    if not Player then return end
+    local player = QBCore.Functions.GetPlayer(source)
+    if not player then return end
     if not (itemName == "lockpick" or itemName == "advancedlockpick") then return end
-    if Player.Functions.RemoveItem(itemName, 1) then
-            TriggerClientEvent("inventory:client:ItemBox", source, QBCore.Shared.Items[itemName], "remove")
+    if player.Functions.RemoveItem(itemName, 1) then
+        TriggerClientEvent("inventory:client:ItemBox", source, QBCore.Shared.Items[itemName], "remove")
     end
 end)
 
@@ -52,7 +51,7 @@ end)
 lib.callback.register('qbx-vehiclekeys:server:getVehicleKeys', function(source)
     local citizenid = QBCore.Functions.GetPlayer(source).PlayerData.citizenid
     local keysList = {}
-    for plate, citizenids in pairs (VehicleList) do
+    for plate, citizenids in pairs (vehicleList) do
         if citizenids[citizenid] then
             keysList[plate] = true
         end
@@ -66,8 +65,8 @@ end)
 function GiveKeys(id, plate)
     local citizenid = QBCore.Functions.GetPlayer(id).PlayerData.citizenid
 
-    if not VehicleList[plate] then VehicleList[plate] = {} end
-    VehicleList[plate][citizenid] = true
+    if not vehicleList[plate] then vehicleList[plate] = {} end
+    vehicleList[plate][citizenid] = true
 
     TriggerClientEvent('QBCore:Notify', id, Lang:t('notify.keys_taken'))
     TriggerClientEvent('qb-vehiclekeys:client:AddKeys', id, plate)
@@ -76,8 +75,8 @@ end
 function RemoveKeys(id, plate)
     local citizenid = QBCore.Functions.GetPlayer(id).PlayerData.citizenid
 
-    if VehicleList[plate] and VehicleList[plate][citizenid] then
-        VehicleList[plate][citizenid] = nil
+    if vehicleList[plate] and vehicleList[plate][citizenid] then
+        vehicleList[plate][citizenid] = nil
     end
 
     TriggerClientEvent('qb-vehiclekeys:client:RemoveKeys', id, plate)
@@ -85,7 +84,7 @@ end
 
 function HasKeys(id, plate)
     local citizenid = QBCore.Functions.GetPlayer(id).PlayerData.citizenid
-    if VehicleList[plate] and VehicleList[plate][citizenid] then
+    if vehicleList[plate] and vehicleList[plate][citizenid] then
         return true
     end
     return false


### PR DESCRIPTION
## Description

Adds the modules, replaces the deprecated export and functions, further use of cache.vehicle, and then some minor style fixes

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
